### PR TITLE
Nodejs 24 GitHub Actions Migration

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -118,6 +118,10 @@ jobs:
     - name: test
       env:
         TOXPYTHON: '${{ matrix.toxpython }}'
+
+        # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
       run: >
         tox -e ${{ matrix.tox_env }} -v
 
@@ -150,6 +154,10 @@ jobs:
       - name: generate coverage report
         env:
           TOXPYTHON: '3.11'
+
+          # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
         run: |
           tox -e py311
 
@@ -189,6 +197,10 @@ jobs:
     - name: generate docs
       env:
         TOXPYTHON: '3.11'
+
+        # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
       run: |
         tox -e docs -v
         ls -l dist/docs

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -118,10 +118,6 @@ jobs:
     - name: test
       env:
         TOXPYTHON: '${{ matrix.toxpython }}'
-
-        # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
-        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
       run: >
         tox -e ${{ matrix.tox_env }} -v
 
@@ -154,10 +150,6 @@ jobs:
       - name: generate coverage report
         env:
           TOXPYTHON: '3.11'
-
-          # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
         run: |
           tox -e py311
 
@@ -197,10 +189,6 @@ jobs:
     - name: generate docs
       env:
         TOXPYTHON: '3.11'
-
-        # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
-        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
       run: |
         tox -e docs -v
         ls -l dist/docs

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -100,10 +100,10 @@ jobs:
 #            os: 'macos-latest'
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python }}
         architecture: ${{ matrix.python_arch }}
@@ -136,10 +136,10 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           architecture: 'x64'
@@ -178,10 +178,10 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.11'
         architecture: 'x64'


### PR DESCRIPTION
# Description

Addresses https://github.com/NatLabRockies/GEOPHIRES-X/issues/473 by updating relevant GitHub Actions to latest versions per https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

# Testing & Verification

Actions run without deprecation warnings: https://github.com/softwareengineerprogrammer/GEOPHIRES/actions/runs/23115216722

---

*Self-reviewed in https://github.com/softwareengineerprogrammer/GEOPHIRES/pull/140*
